### PR TITLE
Bugfix: Alpine Build broken due to missing import

### DIFF
--- a/slscore/common.cpp
+++ b/slscore/common.cpp
@@ -46,6 +46,7 @@
 
 
 #include "common.hpp"
+#include <time.h>
 
 
 /**


### PR DESCRIPTION
I noticed that the current docker image was not building anymore. Adding a missing import seems to have fixed this problem.

This was the error log:
```
[...]
 => CACHED [srt stage-1 2/7] RUN apk update &&    apk upgrade &&    apk add --no-cache openssl libstdc++ &&    adduser -D srt &&    mkdir /etc/sls /logs &&    chown srt /logs           0.0s
 => CACHED [srt build 2/9] RUN apk update &&    apk upgrade &&    apk add --no-cache linux-headers alpine-sdk cmake tcl openssl-dev zlib-dev                                             0.0s
 => CACHED [srt build 3/9] WORKDIR /tmp                                                                                                                                                  0.0s
 => CACHED [srt build 4/9] RUN git clone https://github.com/Haivision/srt.git                                                                                                            0.0s
 => CACHED [srt build 5/9] WORKDIR /tmp/srt                                                                                                                                              0.0s
 => CACHED [srt build 6/9] RUN git checkout master && ./configure && make -j8 && make install                                                                                            0.0s
 => CACHED [srt build 7/9] WORKDIR /tmp/srt-live-server                                                                                                                                  0.0s
 => CACHED [srt build 8/9] COPY srt-live-server/ .                                                                                                                                       0.0s
 => ERROR [srt build 9/9] RUN make -j1                                                                                                                                                   1.1s
------                                                                                                                                                                                        
 > [srt build 9/9] RUN make -j1:                                                                                                                                                              
0.199 g++ -c -g -w -fcompare-debug-second  slscore/SLSLog.cpp -o obj/SLSLog.o                                                                                                                 
0.640 g++ -c -g -w -fcompare-debug-second  slscore/common.cpp -o obj/common.o                                                                                                                 
1.032 slscore/common.cpp: In function 'void sls_gettime_fmt(char*, int64_t, char*)':                                                                                                          
1.032 slscore/common.cpp:111:5: error: 'time' was not declared in this scope                                                                                                                  
1.032   111 |     time (&rawtime);
1.032       |     ^~~~
1.032 slscore/common.cpp:113:16: error: 'localtime' was not declared in this scope
1.032   113 |     timeinfo = localtime (&rawtime);
1.032       |                ^~~~~~~~~
1.032 slscore/common.cpp:114:5: error: 'strftime' was not declared in this scope
1.032   114 |     strftime(timef, sizeof(timef), fmt, timeinfo);
1.032       |     ^~~~~~~~
1.116 make: *** [Makefile:61: obj/common.o] Error 1
------
failed to solve: process "/bin/sh -c make -j1" did not complete successfully: exit code: 2
exit status 1

```